### PR TITLE
Allowing access to the last 32k bytes of ram

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -850,7 +850,7 @@ endif
 define Atmel_SAM3
    $(eval $(Cortex-M3))
    ROM_START      ?= 0x00000000   
-   RAM_START      ?= 0x20000000     
+   RAM_START      ?= 0x20070000     
    INCLUDES       += -I$(BMPTK)/targets/cortex/atmel
    PORT_CHECK     ?= $(CHECK_PORT) $(SERIAL_PORT)  
    RUN_PRE        := $(DUE_BOOTMODE)

--- a/targets/cortex/atmel/sam3xa/source/as_gcc/sam3a4c_flash.ld
+++ b/targets/cortex/atmel/sam3xa/source/as_gcc/sam3a4c_flash.ld
@@ -39,7 +39,7 @@ SEARCH_DIR(.)
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x00080000, LENGTH = 0x00040000
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00010000
+  ram (rwx) : ORIGIN = 0x20078000, LENGTH = 0x00010000
 }
 
 /* The stack size used by the application. NOTE: you need to adjust according to your application. */

--- a/targets/cortex/atmel/sam3xa/source/as_gcc/sam3a4c_sram.ld
+++ b/targets/cortex/atmel/sam3xa/source/as_gcc/sam3a4c_sram.ld
@@ -39,7 +39,7 @@ SEARCH_DIR(.)
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x00080000, LENGTH = 0x00040000
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00010000
+  ram (rwx) : ORIGIN = 0x20078000, LENGTH = 0x00010000
 }
 
 /* The stack size used by the application. NOTE: you need to adjust according to your application. */

--- a/targets/cortex/atmel/sam3xa/source/as_gcc/sam3a8c_flash.ld
+++ b/targets/cortex/atmel/sam3xa/source/as_gcc/sam3a8c_flash.ld
@@ -39,7 +39,7 @@ SEARCH_DIR(.)
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x00080000, LENGTH = 0x00080000
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00018000
+  ram (rwx) : ORIGIN = 0x20070000, LENGTH = 0x00018000
 }
 
 /* The stack size used by the application. NOTE: you need to adjust according to your application. */

--- a/targets/cortex/atmel/sam3xa/source/as_gcc/sam3a8c_sram.ld
+++ b/targets/cortex/atmel/sam3xa/source/as_gcc/sam3a8c_sram.ld
@@ -39,7 +39,7 @@ SEARCH_DIR(.)
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x00080000, LENGTH = 0x00080000
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00018000
+  ram (rwx) : ORIGIN = 0x20070000, LENGTH = 0x00018000
 }
 
 /* The stack size used by the application. NOTE: you need to adjust according to your application. */

--- a/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x4c_flash.ld
+++ b/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x4c_flash.ld
@@ -39,7 +39,7 @@ SEARCH_DIR(.)
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x00080000, LENGTH = 0x00040000
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00010000
+  ram (rwx) : ORIGIN = 0x20078000, LENGTH = 0x00010000
 }
 
 /* The stack size used by the application. NOTE: you need to adjust according to your application. */

--- a/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x4c_sram.ld
+++ b/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x4c_sram.ld
@@ -39,7 +39,7 @@ SEARCH_DIR(.)
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x00080000, LENGTH = 0x00040000
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00010000
+  ram (rwx) : ORIGIN = 0x20078000, LENGTH = 0x00010000
 }
 
 /* The stack size used by the application. NOTE: you need to adjust according to your application. */

--- a/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x4e_flash.ld
+++ b/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x4e_flash.ld
@@ -39,7 +39,7 @@ SEARCH_DIR(.)
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x00080000, LENGTH = 0x00040000
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00010000
+  ram (rwx) : ORIGIN = 0x20078000, LENGTH = 0x00010000
 }
 
 /* The stack size used by the application. NOTE: you need to adjust according to your application. */

--- a/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x4e_sram.ld
+++ b/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x4e_sram.ld
@@ -39,7 +39,7 @@ SEARCH_DIR(.)
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x00080000, LENGTH = 0x00040000
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00010000
+  ram (rwx) : ORIGIN = 0x20078000, LENGTH = 0x00010000
 }
 
 /* The stack size used by the application. NOTE: you need to adjust according to your application. */

--- a/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x8c_flash.ld
+++ b/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x8c_flash.ld
@@ -39,7 +39,7 @@ SEARCH_DIR(.)
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x00080000, LENGTH = 0x00080000
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00018000
+  ram (rwx) : ORIGIN = 0x20070000, LENGTH = 0x00018000
 }
 
 /* The stack size used by the application. NOTE: you need to adjust according to your application. */

--- a/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x8c_sram.ld
+++ b/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x8c_sram.ld
@@ -39,7 +39,7 @@ SEARCH_DIR(.)
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x00080000, LENGTH = 0x00080000
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00018000
+  ram (rwx) : ORIGIN = 0x20070000, LENGTH = 0x00018000
 }
 
 /* The stack size used by the application. NOTE: you need to adjust according to your application. */

--- a/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x8e_flash.ld
+++ b/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x8e_flash.ld
@@ -39,7 +39,7 @@ SEARCH_DIR(.)
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x00080000, LENGTH = 0x00080000
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00018000
+  ram (rwx) : ORIGIN = 0x20070000, LENGTH = 0x00018000
 }
 
 /* The stack size used by the application. NOTE: you need to adjust according to your application. */

--- a/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x8e_sram.ld
+++ b/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x8e_sram.ld
@@ -39,7 +39,7 @@ SEARCH_DIR(.)
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x00080000, LENGTH = 0x00080000
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00018000
+  ram (rwx) : ORIGIN = 0x20070000, LENGTH = 0x00018000
 }
 
 /* The stack size used by the application. NOTE: you need to adjust according to your application. */

--- a/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x8h_flash.ld
+++ b/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x8h_flash.ld
@@ -39,7 +39,7 @@ SEARCH_DIR(.)
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x00080000, LENGTH = 0x00080000
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00018000
+  ram (rwx) : ORIGIN = 0x20070000, LENGTH = 0x00018000
 }
 
 /* The stack size used by the application. NOTE: you need to adjust according to your application. */

--- a/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x8h_sram.ld
+++ b/targets/cortex/atmel/sam3xa/source/as_gcc/sam3x8h_sram.ld
@@ -39,7 +39,7 @@ SEARCH_DIR(.)
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x00080000, LENGTH = 0x00080000
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00018000
+  ram (rwx) : ORIGIN = 0x20070000, LENGTH = 0x00018000
 }
 
 /* The stack size used by the application. NOTE: you need to adjust according to your application. */


### PR DESCRIPTION
This fixes the memory address location of the arduino due ram. 

Sinds ram bank sram0 = 0x2000 0000
and ram bank sram1 = 0x2008 0000

The difference between these banks of ram is 512k bytes ( 0x2008 0000 - 0x2000 0000 = 0x80000 = 524288 bytes) sinds the arduino due has 64k bytes of ram in the first bank(sram0) and 32k bytes of ram in the second bank(sram1) you are left with a gap of 448k bytes. 

In the datasheet they provide a region which is "contiguous" that region is: 
0x2007 0000 - 0x2008 8000 = 0x18000 = 98304 bytes = 96k bytes

see more info about the memory map on page 32 under the table.
[datascheet page 32](http://ww1.microchip.com/downloads/en/devicedoc/atmel-11057-32-bit-cortex-m3-microcontroller-sam3x-sam3a_datasheet.pdf#page=32&zoom=100,0,166)