### PR TITLE
Added include for sam3xa.h

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -891,6 +891,7 @@ define Atmel_SAM3
    ROM_START      ?= 0x00000000   
    RAM_START      ?= 0x20000000     
    INCLUDES       += -I$(BMPTK)/targets/cortex/atmel
+   INCLUDES       += -I$(BMPTK)/targets/cortex/atmel/sam3xa/include
    PORT_CHECK     ?= $(CHECK_PORT) $(SERIAL_PORT)  
    RUN_PRE        := $(DUE_BOOTMODE)
    # was al gezet?


### PR DESCRIPTION
Added -I$(BMPTK)/targets/cortex/atmel/sam3xa/include to includes for Atmel_SAM3 based chips. To make sam3xa.h visible to include directly.