### PR TITLE
fixed invalid flash params

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -994,7 +994,7 @@ define STM32
    RAM_START      ?= 0x20000000
    INCLUDES       += -I$(BMPTK)/targets/cortex/stm32
    RESULTS         += $(HEX) $(BIN)
-   RUN            ?= $(STM32_CLI) --reset write $(BIN) 0x08000000
+   RUN            ?= $(STM32_CLI) -Rst -P $(BIN) 0x08000000 -v
    #RUN            ?= $(STM32_FLASH) -w $(HEX) -v
    RUN_PAUSE      ?= $(PAUSE)
 endef


### PR DESCRIPTION
The ST-Link CLI tool has different parameters, with 'write' nothing happens, it needs to be '-P'.