### PR TITLE
Update Makefile.inc

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -19,7 +19,11 @@
 # nor periods (problems on xtensa)
 
 VERSION := V05_00_work_in_progress_2021_01_04
-WSL := $(strip $(shell grep -qE "(microsoft|Microsoft|WSL)" /proc/version @> /dev/null && printf true))
+ifeq ($(WSL),true)
+   WSL := $(strip $(shell grep -qE "(microsoft|Microsoft|WSL)" /proc/version @> /dev/null && printf true))
+endif
+# oude regel
+#  WSL := $(strip $(shell grep -qE "(microsoft|Microsoft|WSL)" /proc/version @> /dev/null && printf true))
 
 #============================================================================
 #


### PR DESCRIPTION
Zorgen dat deze file alleen werkt onder WSL. Nu komt er een storende boodschap onder Windows gebruikers dat hun programma GREP niet kan vinden en dat klopt.
Het veroorzaakt verder gene storing en  bij een volgende installatie zijn de studenten er vanaf